### PR TITLE
fix: Claude Codeのsandboxからgitコマンドをexcludeしてgit pushを可能にする

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -12,6 +12,7 @@
     "enabled": true,
     "autoAllowBashIfSandboxed": true,
     "enableWeakerNetworkIsolation": true,
+    "excludedCommands": ["git"],
     "network": {
       "allowedDomains": [
         "api.github.com",
@@ -27,9 +28,7 @@
         "~/.bash_history",
         "~/.zsh_history"
       ],
-      "allowRead": [
-        "~/.ssh/known_hosts"
-      ]
+      "allowRead": []
     }
   },
   "permissions": {

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -26,6 +26,9 @@
         "~/.config/gcloud",
         "~/.bash_history",
         "~/.zsh_history"
+      ],
+      "allowRead": [
+        "~/.ssh/known_hosts"
       ]
     }
   },


### PR DESCRIPTION
## What（何を変更したか）
- `claude/settings.json` に `"excludedCommands": ["git"]` を追加
- `allowRead` から `~/.ssh/known_hosts` を削除（不要になったため）

## Why（なぜ変更が必要だったか）

Claude Codeのsandbox設定では、デフォルトで `~/.ssh/known_hosts` への読み取りアクセスが
制限されており、SSH経由での `git push` が `hostkeys_find_by_key_hostfile` エラーで
失敗していた。

`excludedCommands: ["git"]` を設定することで、git コマンドをsandboxの対象外とし、
ホストシステムのSSH設定を通じて正常にリモートリポジトリへpushできるようにした。
これにより `~/.ssh/known_hosts` の一時的なallowRead設定も不要となり削除した。

## 💡 Discussion Points / Technical Concerns
- `excludedCommands` の設定は次回のClaude Codeセッション起動時に有効になる
- 現セッションでは設定が反映されないため、git pushにはサンドボックス無効化が必要