### PR TITLE
fix: Makefile から削除済み CLAUDE.local.md.sample のターゲットを除去

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ deps:
 		brew install --cask font-plemol-jp-nf 2>/dev/null || true; \
 	fi
 
-symlink: $(HOME)/.vim $(HOME)/.zshrc.local $(HOME)/.config/nvim $(HOME)/.config/ghostty $(HOME)/.config/starship.toml $(HOME)/.claude/commands $(HOME)/.claude/agents $(HOME)/.claude/rules $(HOME)/.claude/skills $(HOME)/.claude/settings.json $(HOME)/.claude/statusline.sh $(HOME)/.claude/hooks $(HOME)/.claude/CLAUDE.md $(HOME)/.claude/CLAUDE.local.md
+symlink: $(HOME)/.vim $(HOME)/.zshrc.local $(HOME)/.config/nvim $(HOME)/.config/ghostty $(HOME)/.config/starship.toml $(HOME)/.claude/commands $(HOME)/.claude/agents $(HOME)/.claude/rules $(HOME)/.claude/skills $(HOME)/.claude/settings.json $(HOME)/.claude/statusline.sh $(HOME)/.claude/hooks $(HOME)/.claude/CLAUDE.md
 	$(foreach src, $(srcs), \
 	  ln -fs $(PWD)/$(src) $(HOME)/.$(src); \
 	  )
@@ -61,6 +61,3 @@ $(HOME)/.claude/hooks:
 
 $(HOME)/.claude/CLAUDE.md:
 	ln -fs $(PWD)/claude/CLAUDE.md $@
-
-$(HOME)/.claude/CLAUDE.local.md:
-	cp $(PWD)/claude/CLAUDE.local.md.sample $@


### PR DESCRIPTION
## What
`Makefile` から `$(HOME)/.claude/CLAUDE.local.md` ターゲットと、`symlink` ターゲットの依存リスト内の同名エントリを削除する。

## Why
`claude/CLAUDE.local.md.sample` は意図的に削除済みだが、Makefile 側に
sample からの `cp` ターゲットが残っていたため、`make symlink` が以下のエラーで落ちる状態になっていた。

```
$ make symlink
cp /Users/saxsir/src/github.com/saxsir/dotfiles/claude/CLAUDE.local.md.sample /Users/saxsir/.claude/CLAUDE.local.md
cp: cannot stat '...CLAUDE.local.md.sample': No such file or directory
make: *** [/Users/saxsir/.claude/CLAUDE.local.md] Error 1
```

`~/.claude/CLAUDE.local.md` は dotfiles 管理から外す方針なので、Makefile からターゲットごと削除する。

## 検証
- `make -n symlink` のドライランで CLAUDE.local.md 関連の `cp` が出力されないことを確認
- 既存の `$(HOME)/.claude/CLAUDE.md` symlink ターゲットには影響しないことを diff で確認