### PR TITLE
feat: Brewfile と secretlint(pre-commit) を追加

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -2,8 +2,15 @@
 README.md
 LICENSE
 Makefile
+Brewfile
+Brewfile.lock.json
 .gitignore
 .git
+.pre-commit-config.yaml
+.secretlintrc.json
+package.json
+package-lock.json
+node_modules
 lima
 misc
 

--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,8 @@ dot_config/ghostty/config.bak
 dot_claude/CLAUDE.local.md
 .serena/cache
 
+# Node (secretlint 用)
+node_modules/
+
 # 旧 oh-my-zsh/ ディレクトリ (zinit へ移行済。ローカル削除待ち)
 oh-my-zsh/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+  - repo: local
+    hooks:
+      - id: secretlint
+        name: secretlint
+        entry: npx secretlint
+        language: system
+        types: [text]

--- a/.secretlintrc.json
+++ b/.secretlintrc.json
@@ -1,0 +1,7 @@
+{
+  "rules": [
+    {
+      "id": "@secretlint/secretlint-rule-preset-recommend"
+    }
+  ]
+}

--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,15 @@
+# dotfiles の動作に必要な最小セット。
+# 各自の環境に応じて追加する場合は `brew bundle add <formula>` で書き込める。
+
+# chezmoi 本体とプロンプト
+brew "chezmoi"
+brew "starship"
+
+# pre-commit (secretlint hook の実行に必要)
+brew "pre-commit"
+
+# secretlint を npx 経由で動かすための Node
+brew "node"
+
+# Nerd Font (ターミナル)
+cask "font-plemol-jp-nf"

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,21 @@ deps:
 	fi
 
 # pre-commit hook を .git/hooks にインストール (secretlint 等を有効化)
+# core.hooksPath が孤児パス (実体なし) を指している場合は自動で unset する。
+# 実体があるパスを指している場合はユーザに通知して abort (意図的な設定の上書きを避ける)。
 hooks:
 	@command -v pre-commit >/dev/null 2>&1 || { echo "pre-commit が見つからない: make deps を先に実行"; exit 1; }
+	@hp=$$(git config --get core.hooksPath 2>/dev/null); \
+	if [ -n "$$hp" ]; then \
+	  if [ ! -d "$$hp" ]; then \
+	    echo "[hooks] 孤児な core.hooksPath ($$hp) を unset します"; \
+	    git config --unset core.hooksPath; \
+	  else \
+	    echo "[hooks] core.hooksPath=$$hp が設定済みです。pre-commit と共存するか手動で対応してください:"; \
+	    echo "  git config --unset core.hooksPath  # pre-commit を使う"; \
+	    exit 1; \
+	  fi; \
+	fi
 	pre-commit install
 
 # 初回のみ: chezmoi の設定ファイル ~/.config/chezmoi/chezmoi.toml を生成

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,21 @@
 PWD := $(shell pwd)
 
-.PHONY: all deps init apply diff edit re-add merge help
+.PHONY: all deps init apply diff edit re-add merge hooks help
 
-# デフォルト: 依存ツールを揃えて apply
-all: deps apply
+# デフォルト: 依存ツールを揃えて apply、pre-commit hook を install
+all: deps apply hooks
 
 deps:
 	@command -v brew >/dev/null 2>&1 || { echo "Homebrew が必要です: https://brew.sh"; exit 1; }
-	@command -v chezmoi >/dev/null 2>&1 || brew install chezmoi
-	@command -v starship >/dev/null 2>&1 || brew install starship
-	@brew install --cask font-plemol-jp-nf 2>/dev/null || true
+	brew bundle --file=Brewfile
+	@if [ -f package.json ]; then \
+	  npm install --silent; \
+	fi
+
+# pre-commit hook を .git/hooks にインストール (secretlint 等を有効化)
+hooks:
+	@command -v pre-commit >/dev/null 2>&1 || { echo "pre-commit が見つからない: make deps を先に実行"; exit 1; }
+	pre-commit install
 
 # 初回のみ: chezmoi の設定ファイル ~/.config/chezmoi/chezmoi.toml を生成
 init:
@@ -46,11 +52,12 @@ merge:
 
 help:
 	@echo "Targets:"
-	@echo "  all      - deps + apply (デフォルト)"
-	@echo "  deps     - brew で chezmoi/starship/font をインストール"
+	@echo "  all      - deps + apply + hooks (デフォルト)"
+	@echo "  deps     - brew bundle + npm install"
 	@echo "  init     - 初回のみ chezmoi 設定ファイルを生成"
 	@echo "  apply    - source → ~/ に反映 (標準の方向)"
 	@echo "  diff     - apply 前の差分確認"
 	@echo "  edit     - source 側を編集して --apply (FILE=...)"
 	@echo "  re-add   - ~/ の編集内容を source に取り込み (FILE=... 任意)"
 	@echo "  merge    - 衝突時の 3-way merge (FILE=...)"
+	@echo "  hooks    - pre-commit hook を install (secretlint)"

--- a/README.md
+++ b/README.md
@@ -16,15 +16,26 @@ $ make
 
 - リポジトリルート — chezmoi の source root (`dot_*` / `*.tmpl` 等が並ぶ)
 - `Makefile` — `chezmoi apply` のエントリポイントと依存ツール (brew 等) のインストール
-- `.chezmoiignore` — `Makefile` / `README.md` / `lima/` / `misc/` 等を chezmoi 適用対象から除外
+- `Brewfile` — 依存パッケージ (chezmoi/starship/pre-commit/node + フォント) を `brew bundle` で管理
+- `.pre-commit-config.yaml` / `.secretlintrc.json` / `package.json` — secretlint によるコミット時シークレット検出
+- `.chezmoiignore` — リポメタ (`Makefile` / `README.md` / `Brewfile` / `lima` / `misc` 等) を chezmoi 適用対象から除外
 - `lima/`, `misc/` — chezmoi 管理外 (リポメタ)
 
 ## 主なコマンド
 
 ```
-make             # = make deps apply
-make deps        # brew で chezmoi/starship/font 等を揃える
+make             # = make deps apply hooks
+make deps        # brew bundle + npm install (Brewfile + package.json)
 make apply       # chezmoi apply (~/ にファイル配置)
 make diff        # 適用前に差分確認
-chezmoi edit ~/.zshrc   # ソース側を編集 (apply は別途)
+make hooks       # pre-commit hook を install
+make help        # 全 target 一覧
+```
+
+## シークレット検出
+
+`pre-commit install` 後は `git commit` 時に `secretlint` が自動的に走り、AWS キーや GitHub トークン等が混入していると commit が失敗します。手動チェック:
+
+```
+npx secretlint "**/*"
 ```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "private": true,
+  "devDependencies": {
+    "@secretlint/secretlint-rule-preset-recommend": "^9.0.0",
+    "secretlint": "^9.0.0"
+  }
+}


### PR DESCRIPTION
## なぜ

- 依存パッケージ (chezmoi/starship/pre-commit/node + フォント) が Makefile に直書きされており、新規マシンで `brew install` を 1 個ずつ呼んでいた。`Brewfile` で宣言的に管理する方が `brew bundle` 一発で済み拡張も容易
- AWS access key や GitHub token を `chezmoi add` 後にうっかり commit するリスクが残っていたので、コミット時にシークレット検出を走らせる

## 変更内容

### Brewfile (最小セット)

```ruby
brew "chezmoi"
brew "starship"
brew "pre-commit"
brew "node"
cask "font-plemol-jp-nf"
```

各自の環境で必要な追加パッケージは `brew bundle add <formula>` で書き込み可能。

### secretlint + pre-commit (mizchi/chezmoi-dotfiles 方式)

- `.secretlintrc.json`: `@secretlint/secretlint-rule-preset-recommend` を有効化 (AWS / GCP / GitHub / Slack トークン等)
- `.pre-commit-config.yaml`: `language: system` で `npx secretlint` を呼ぶローカルフック
- `package.json`: `secretlint` v9 を devDependency 化

### Makefile 改修

- `deps` ターゲットを `brew bundle --file=Brewfile` ベースに変更
- `package.json` があれば `npm install` も実行
- `hooks` ターゲット (`pre-commit install`) を追加し `all` に組み込み
- `make all = deps + apply + hooks`

### .chezmoiignore に追加

`Brewfile` / `Brewfile.lock.json` / `.pre-commit-config.yaml` / `.secretlintrc.json` / `package.json` / `package-lock.json` / `node_modules` をリポメタとして chezmoi 適用対象から除外。

## 動作確認

```bash
# 新規マシン想定
make            # brew bundle + chezmoi apply + pre-commit install
make help       # ターゲット一覧

# 手動シークレット検出
npx secretlint "**/*"

# 試しに commit してみる
git commit ...  # secretlint が走る
```

## 別PR候補

- OS別 Makefile 分割 (linux.mk/macos.mk) — 現状 macOS のみなので必要になったら
