### PR TITLE
refactor: dot_zshrc を dot_zsh/ 配下にモジュラ化 (S2)

### DIFF
--- a/dot_zsh/base.rc.zsh
+++ b/dot_zsh/base.rc.zsh
@@ -1,0 +1,29 @@
+# シェル素の設定 (オプション / alias / 補完)
+
+# ============================================================
+# シェルオプション
+# ============================================================
+setopt hist_ignore_all_dups
+
+# ============================================================
+# エイリアス
+# ============================================================
+alias vi='vi -u NONE'
+alias vim='nvim'
+alias -g G='| grep'
+alias -g L='| lv'
+alias -g V='| vim -'
+alias -g C='| pbcopy'
+alias matrix="cmatrix -s -u 6"
+alias gce='git commit --allow-empty'
+alias claude-vm="limactl shell claude-dev -- bash -c 'claude --dangerously-skip-permissions'"
+
+# ============================================================
+# 補完 (zinit のプラグインを活かすため最後に compinit)
+# ============================================================
+autoload -Uz compinit
+if [[ -n ${ZDOTDIR}/.zcompdump(#qN.mh+24) ]]; then
+  compinit
+else
+  compinit -C
+fi

--- a/dot_zsh/env.rc.zsh
+++ b/dot_zsh/env.rc.zsh
@@ -1,0 +1,37 @@
+# 環境変数と PATH 追加
+# (ツール起動 / 補完登録は tool.rc.zsh)
+
+# Editor
+export EDITOR="nvim"
+export VISUAL="$EDITOR"
+export CLAUDE_PATH="$HOME/.local/bin/claude"
+
+# go
+if [ -d "/usr/local/go/" ]; then
+  export PATH=/usr/local/go/bin:$PATH
+  export GOPATH=$HOME
+  export GOROOT=$(go env GOROOT)
+  export PATH=$GOPATH/bin:$PATH
+fi
+
+# uv / pip 等のユーザーローカル bin
+export PATH="$PATH:$HOME/.local/bin"
+
+# pnpm
+export PNPM_HOME="$HOME/Library/pnpm"
+case ":$PATH:" in
+  *":$PNPM_HOME:"*) ;;
+  *) export PATH="$PNPM_HOME:$PATH" ;;
+esac
+
+# Antigravity
+export PATH="$HOME/.antigravity/antigravity/bin:$PATH"
+
+# bun
+export BUN_INSTALL="$HOME/.bun"
+export PATH="$BUN_INSTALL/bin:$PATH"
+
+# Snowflake CLI (macOS app bundle 内)
+if [ -d "$HOME/Applications/SnowflakeCLI.app/Contents/MacOS" ]; then
+  export PATH="$HOME/Applications/SnowflakeCLI.app/Contents/MacOS:$PATH"
+fi

--- a/dot_zsh/macos.rc.zsh
+++ b/dot_zsh/macos.rc.zsh
@@ -1,0 +1,15 @@
+# macOS 固有の初期化
+# loader (dot_zshrc) で uname == Darwin の時だけ source される
+
+# Homebrew (Apple Silicon)
+eval "$(/opt/homebrew/bin/brew shellenv)"
+
+# GNU coreutils (date 等の構文を Linux と揃える)
+# refs http://qiita.com/catatsuy/items/00ebf78f56960b6d43c2#2-4
+if [ -d /opt/homebrew/opt/coreutils/libexec/gnubin ]; then
+  export PATH="/opt/homebrew/opt/coreutils/libexec/gnubin:$PATH"
+  export MANPATH=/opt/homebrew/opt/coreutils/libexec/gnuman:$MANPATH
+else
+  export LSCOLORS=gxfxcxdxbxegedabagacad
+  alias ls='ls -G'
+fi

--- a/dot_zsh/tool.rc.zsh
+++ b/dot_zsh/tool.rc.zsh
@@ -1,0 +1,127 @@
+# 外部ツール統合 (プラグインマネージャ / プロンプト / 補完 / フック)
+
+# ============================================================
+# zinit (プラグインマネージャ)
+# ============================================================
+ZINIT_HOME="${XDG_DATA_HOME:-${HOME}/.local/share}/zinit/zinit.git"
+if [[ ! -d "$ZINIT_HOME" ]]; then
+  mkdir -p "$(dirname "$ZINIT_HOME")"
+  git clone https://github.com/zdharma-continuum/zinit.git "$ZINIT_HOME"
+fi
+source "${ZINIT_HOME}/zinit.zsh"
+
+# プラグイン (turbo モードで遅延読み込み)
+zinit wait lucid for \
+  OMZL::git.zsh \
+  OMZL::directories.zsh \
+  atload'bindkey "^r" peco-select-history; bindkey "^p" peco-src; bindkey "^j" select_worktree' OMZL::key-bindings.zsh \
+  OMZP::git \
+  atload"_zsh_autosuggest_start" zsh-users/zsh-autosuggestions \
+  zsh-users/zsh-completions
+
+ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE="fg=green,bold"
+
+# ============================================================
+# starship (プロンプト)
+# ============================================================
+eval "$(starship init zsh)"
+
+# ============================================================
+# 関数 (peco / ghq / fzf / aws-vault)
+# ============================================================
+
+# aws-vault exec の薄ラッパ
+function avt {
+  profile=$1; shift
+  aws-vault exec $profile -- aws "$@";
+}
+
+# peco x history
+function peco-select-history() {
+  local tac
+  if which tac > /dev/null; then
+    tac="tac"
+  else
+    tac="tail -r"
+  fi
+  BUFFER=$(fc -l -n 1 | eval $tac | peco --query "$LBUFFER")
+  CURSOR=$#BUFFER
+  zle clear-screen
+}
+
+# peco x ghq (リポジトリ移動)
+function peco-src () {
+  local selected_dir=$(ghq list -p | peco --query "$LBUFFER")
+  if [ -n "$selected_dir" ]; then
+    BUFFER="cd ${selected_dir}"
+    zle accept-line
+  fi
+  zle clear-screen
+}
+
+# fzf x git worktree
+function select_worktree() {
+  local worktrees
+  worktrees=$(git worktree list --porcelain | awk '/worktree / {print $2}')
+  if [[ -z "$worktrees" ]]; then
+    echo "No worktrees found."
+    return 1
+  fi
+  local selected
+  selected=$(echo "$worktrees" | fzf)
+  if [[ -n "$selected" ]]; then
+    BUFFER="cd ${selected}"
+    zle accept-line
+  fi
+  zle clear-screen
+}
+
+# キーバインド (peco/fzf 関数を ZLE に登録)
+zle -N peco-select-history
+zle -N peco-src
+zle -N select_worktree
+bindkey '^r' peco-select-history
+bindkey '^p' peco-src
+bindkey '^j' select_worktree
+
+# ============================================================
+# tmux 連携: cd 時に window 名を repo 名 / dir 名に同期
+# ============================================================
+if [[ -n "$TMUX" ]]; then
+  autoload -Uz add-zsh-hook
+  _tmux_update_window_name() {
+    local name
+    local toplevel
+    toplevel=$(git rev-parse --show-toplevel 2>/dev/null)
+    if [[ -n "$toplevel" ]]; then
+      name=$(basename "$toplevel")
+    else
+      name=$(basename "$PWD")
+    fi
+    tmux rename-window "$name"
+  }
+  add-zsh-hook chpwd _tmux_update_window_name
+  _tmux_update_window_name
+fi
+
+# ============================================================
+# その他ツール初期化
+# ============================================================
+
+# direnv
+if which direnv > /dev/null; then eval "$(direnv hook zsh)"; fi
+
+# Google Cloud SDK
+if [ -f "$HOME/google-cloud-sdk/path.zsh.inc" ]; then source "$HOME/google-cloud-sdk/path.zsh.inc"; fi
+if [ -f "$HOME/google-cloud-sdk/completion.zsh.inc" ]; then source "$HOME/google-cloud-sdk/completion.zsh.inc"; fi
+
+# mise
+eval "$(mise activate zsh)"
+
+# git-wt
+if command -v git-wt &> /dev/null; then
+  eval "$(git wt --init zsh)"
+fi
+
+# bun completion
+[ -s "$HOME/.bun/_bun" ] && source "$HOME/.bun/_bun"

--- a/dot_zshrc
+++ b/dot_zshrc
@@ -1,224 +1,29 @@
 # ============================================================
-# 起動時間プロファイリング（開始）
+# 起動時間プロファイリング (開始)
+# 有効化したい時は次行をアンコメント (zprof のレポートが終了時に出る)
 # ============================================================
 # zmodload zsh/zprof
 
 # ============================================================
-# Homebrew
+# モジュール読み込み (~/.zsh/*.rc.zsh)
+# 役割分担:
+#   macos.rc.zsh - macOS 固有 (Homebrew, GNU coreutils)
+#   env.rc.zsh   - 環境変数と PATH 追加
+#   tool.rc.zsh  - zinit, mise, peco/ghq, direnv 等のツール統合
+#   base.rc.zsh  - シェルオプション / alias / compinit
 # ============================================================
-eval "$(/opt/homebrew/bin/brew shellenv)"
-
-# ============================================================
-# 環境変数・PATH
-# ============================================================
-export EDITOR="nvim"
-export VISUAL="$EDITOR"
-export CLAUDE_PATH="$HOME/.local/bin/claude"
-
-# coreutils
-# refs http://qiita.com/catatsuy/items/00ebf78f56960b6d43c2#2-4
-if [ -d /opt/homebrew/opt/coreutils/libexec/gnubin ]; then
-  export PATH="/opt/homebrew/opt/coreutils/libexec/gnubin:$PATH"
-  export MANPATH=/opt/homebrew/opt/coreutils/libexec/gnuman:$MANPATH
-else
-  export LSCOLORS=gxfxcxdxbxegedabagacad
-  alias ls='ls -G'
-fi
-
-# go
-if [ -d "/usr/local/go/" ]; then
-  export PATH=/usr/local/go/bin:$PATH
-  export GOPATH=$HOME
-  export GOROOT=$(go env GOROOT)
-  export PATH=$GOPATH/bin:$PATH
-fi
-
-# uv / pip
-export PATH="$PATH:$HOME/.local/bin"
-
-# pnpm
-export PNPM_HOME="$HOME/Library/pnpm"
-case ":$PATH:" in
-  *":$PNPM_HOME:"*) ;;
-  *) export PATH="$PNPM_HOME:$PATH" ;;
-esac
-
-# Added by Antigravity
-export PATH="$HOME/.antigravity/antigravity/bin:$PATH"
+[[ "$(uname)" = "Darwin" && -f ~/.zsh/macos.rc.zsh ]] && source ~/.zsh/macos.rc.zsh
+[[ -f ~/.zsh/env.rc.zsh ]] && source ~/.zsh/env.rc.zsh
+[[ -f ~/.zsh/tool.rc.zsh ]] && source ~/.zsh/tool.rc.zsh
+[[ -f ~/.zsh/base.rc.zsh ]] && source ~/.zsh/base.rc.zsh
 
 # ============================================================
-# プラグインマネージャ（zinit）
-# ============================================================
-ZINIT_HOME="${XDG_DATA_HOME:-${HOME}/.local/share}/zinit/zinit.git"
-if [[ ! -d "$ZINIT_HOME" ]]; then
-  mkdir -p "$(dirname "$ZINIT_HOME")"
-  git clone https://github.com/zdharma-continuum/zinit.git "$ZINIT_HOME"
-fi
-source "${ZINIT_HOME}/zinit.zsh"
-
-# プラグイン（turboモードで遅延読み込み）
-zinit wait lucid for \
-  OMZL::git.zsh \
-  OMZL::directories.zsh \
-  atload'bindkey "^r" peco-select-history; bindkey "^p" peco-src; bindkey "^j" select_worktree' OMZL::key-bindings.zsh \
-  OMZP::git \
-  atload"_zsh_autosuggest_start" zsh-users/zsh-autosuggestions \
-  zsh-users/zsh-completions
-
-# autosuggestのスタイル設定
-ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE="fg=green,bold"
-
-# ============================================================
-# プロンプト
-# ============================================================
-eval "$(starship init zsh)"
-
-# ============================================================
-# シェルオプション
-# ============================================================
-setopt hist_ignore_all_dups
-
-# ============================================================
-# エイリアス
-# ============================================================
-alias vi='vi -u NONE'
-alias vim='nvim'
-alias -g G='| grep'
-alias -g L='| lv'
-alias -g V='| vim -'
-alias -g C='| pbcopy'
-alias matrix="cmatrix -s -u 6"
-alias gce='git commit --allow-empty'
-alias claude-vm="limactl shell claude-dev -- bash -c 'claude --dangerously-skip-permissions'"
-
-# ============================================================
-# 関数
-# ============================================================
-
-# Wrap aws-vault exec
-function avt {
-  profile=$1; shift
-  aws-vault exec $profile -- aws "$@";
-}
-
-# peco: 履歴検索
-function peco-select-history() {
-  local tac
-  if which tac > /dev/null; then
-    tac="tac"
-  else
-    tac="tail -r"
-  fi
-  BUFFER=$(fc -l -n 1 | eval $tac | peco --query "$LBUFFER")
-  CURSOR=$#BUFFER
-  zle clear-screen
-}
-
-# peco: リポジトリ移動
-function peco-src () {
-  local selected_dir=$(ghq list -p | peco --query "$LBUFFER")
-  if [ -n "$selected_dir" ]; then
-    BUFFER="cd ${selected_dir}"
-    zle accept-line
-  fi
-  zle clear-screen
-}
-
-# peco x git worktree
-function select_worktree() {
-  local worktrees
-  worktrees=$(git worktree list --porcelain | awk '/worktree / {print $2}')
-  if [[ -z "$worktrees" ]]; then
-    echo "No worktrees found."
-    return 1
-  fi
-  local selected
-  selected=$(echo "$worktrees" | fzf)
-  if [[ -n "$selected" ]]; then
-    BUFFER="cd ${selected}"
-    zle accept-line
-  fi
-  zle clear-screen
-}
-
-# ============================================================
-# キーバインド
-# ============================================================
-zle -N peco-select-history
-zle -N peco-src
-zle -N select_worktree
-bindkey '^r' peco-select-history
-bindkey '^p' peco-src
-bindkey '^j' select_worktree
-
-# ============================================================
-# tmux連携
-# ============================================================
-if [[ -n "$TMUX" ]]; then
-  autoload -Uz add-zsh-hook
-  _tmux_update_window_name() {
-    local name
-    local toplevel
-    toplevel=$(git rev-parse --show-toplevel 2>/dev/null)
-    if [[ -n "$toplevel" ]]; then
-      name=$(basename "$toplevel")
-    else
-      name=$(basename "$PWD")
-    fi
-    tmux rename-window "$name"
-  }
-  add-zsh-hook chpwd _tmux_update_window_name
-  _tmux_update_window_name
-fi
-
-# ============================================================
-# ツール初期化
-# ============================================================
-
-# direnv
-if which direnv > /dev/null; then eval "$(direnv hook zsh)"; fi
-
-# Google Cloud SDK
-if [ -f "$HOME/google-cloud-sdk/path.zsh.inc" ]; then source "$HOME/google-cloud-sdk/path.zsh.inc"; fi
-if [ -f "$HOME/google-cloud-sdk/completion.zsh.inc" ]; then source "$HOME/google-cloud-sdk/completion.zsh.inc"; fi
-
-# mise
-eval "$(mise activate zsh)"
-
-# git-wt
-if command -v git-wt &> /dev/null; then
-  eval "$(git wt --init zsh)"
-fi
-
-# bun completions
-[ -s "$HOME/.bun/_bun" ] && source "$HOME/.bun/_bun"
-
-# bun
-export BUN_INSTALL="$HOME/.bun"
-export PATH="$BUN_INSTALL/bin:$PATH"
-
-# Snowflake CLI
-if [ -d "$HOME/Applications/SnowflakeCLI.app/Contents/MacOS" ]; then
-  export PATH="$HOME/Applications/SnowflakeCLI.app/Contents/MacOS:$PATH"
-fi
-
-# ============================================================
-# 補完
-# ============================================================
-autoload -Uz compinit
-if [[ -n ${ZDOTDIR}/.zcompdump(#qN.mh+24) ]]; then
-  compinit
-else
-  compinit -C
-fi
-
-# ============================================================
-# パス重複除去
+# パス重複除去 (全 source 後)
 # ============================================================
 typeset -U path
 
 # ============================================================
-# 起動時間プロファイリング（終了）・zcompile
+# 起動時間プロファイリング (終了)・zcompile
 # ============================================================
 if type zprof > /dev/null 2>&1; then
   zprof | less


### PR DESCRIPTION
## What

232 行のモノリシック `dot_zshrc` を以下 4 モジュールに分割し、loader はそれらを順序立てて `source` するだけにする。

| ファイル | 行数 | 役割 |
|---------|------|------|
| `dot_zsh/macos.rc.zsh` | 15 | Homebrew `shellenv`, GNU coreutils PATH (Darwin の時のみ source) |
| `dot_zsh/env.rc.zsh` | 37 | `EDITOR` / `VISUAL` / `CLAUDE_PATH`, PATH 追加 (go, pnpm, antigravity, bun, snowflake-cli) |
| `dot_zsh/tool.rc.zsh` | 127 | zinit + プラグイン, starship, peco/ghq/fzf 関数とキーバインド, tmux 連携, direnv, gcloud, mise, git-wt, bun completion, `avt` |
| `dot_zsh/base.rc.zsh` | 29 | `setopt`, alias, compinit |
| `dot_zshrc` | 37 | プロファイル制御 + 上記 4 つの source + `typeset -U path` + zcompile |

## Why

- 編集対象が局所化される (alias 1 個追加するために 232 行のファイルを開かなくてよい)
- OS 分岐が綺麗 (`[[ "\Darwin" = "Darwin" ]] && source ...` で macos.rc.zsh をスキップ)
- 起動時間: `source` 4 回が増えるが軽量 (パイプ無し)。前後比較は手元で `ENABLE_STARTUP_PROFILING=1 zsh -i -c exit` で確認可能

## 動作確認

- `zsh -n` (構文): 全ファイル OK
- `ZDOTDIR=test zsh -i` で source 検証 → エラーなし、`peco-select-history` / `avt` / `alias vim=nvim` / `EDITOR=nvim` が正しく定義されることを確認

## 後続

- PR4 (devbox + direnv): `dot_zsh/tool.rc.zsh` に hook を追加する形で乗っかれる

Refs: UMBRELLA.md S2 / PR3