### PR TITLE
feat: devbox + direnv をプロジェクト環境管理として統合 (S5)

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -11,5 +11,9 @@ brew "pre-commit"
 # secretlint を npx 経由で動かすための Node
 brew "node"
 
+# プロジェクト単位の環境変数 / シェル切り替え
+# devbox は Homebrew core に無いため `curl -fsSL https://get.jetify.com/devbox | bash` で別途導入
+brew "direnv"
+
 # Nerd Font (ターミナル)
 cask "font-plemol-jp-nf"

--- a/dot_gitignore_global
+++ b/dot_gitignore_global
@@ -24,8 +24,11 @@ Session.vim
 # refs https://github.com/github/gitignore/blob/master/Global/IPythonNotebook.gitignore
 .ipynb_checkpoints/
 
-# direnv
+# direnv / devbox (プロジェクトに .envrc を commit する場合は !.envrc で個別 unignore する)
 .envrc
+.envrc.local
+.direnv/
+.devbox/
 
 # local_dump
 # 本番環境のDB dumpとかをよく置く

--- a/dot_zsh/tool.rc.zsh
+++ b/dot_zsh/tool.rc.zsh
@@ -125,3 +125,8 @@ fi
 
 # bun completion
 [ -s "$HOME/.bun/_bun" ] && source "$HOME/.bun/_bun"
+
+# devbox completion (devbox 本体は Brewfile のコメント参照: 別途 curl install)
+if command -v devbox >/dev/null 2>&1; then
+  eval "$(devbox completion zsh)"
+fi


### PR DESCRIPTION
## What

- `Brewfile` に `brew "direnv"` を追加 (devbox は Homebrew core に無いため別途 curl install する旨をコメント明記)
- `dot_zsh/tool.rc.zsh` に `devbox completion` の条件付き eval を追加 (direnv hook は既存維持)
- `dot_gitignore_global` に `.envrc.local`, `.direnv/`, `.devbox/` を追加。`.envrc` 行のコメントを「project で commit したい時は `\!.envrc` で個別 unignore」運用に更新

## Why

UMBRELLA.md S5 の役割分担に沿って各ツールの前提を整える:

| ツール | 役割 |
|--------|------|
| mise   | ホーム / プロジェクト共通の言語ランタイム (PR5) |
| devbox | プロジェクト固有の Nix-based reproducible env |
| direnv | プロジェクト単位の env / secret ローダー (`devbox shell` 自動化にも使う) |

## 補足

- `dot_config/direnv/direnvrc` (共有関数置き場) は **作らなかった**。共有したい関数 (`use_devbox` の独自版など) が出た時に追加する方針。speculative なコードを置かない原則に従う

## ベース

PR #87 (`refactor/zshrc-modular`) ベース。先に PR #87 がマージされたら master ベースに rebase。

Refs: UMBRELLA.md S5 / PR4