### PR TITLE
feat: mise を Brewfile / Makefile / chezmoi で自動化 (S3)

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -15,5 +15,8 @@ brew "node"
 # devbox は Homebrew core に無いため `curl -fsSL https://get.jetify.com/devbox | bash` で別途導入
 brew "direnv"
 
+# 言語ランタイム / CLI バージョン管理 (~/.config/mise/config.toml)
+brew "mise"
+
 # Nerd Font (ターミナル)
 cask "font-plemol-jp-nf"

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 PWD := $(shell pwd)
 
-.PHONY: all deps init apply diff edit re-add merge hooks help
+.PHONY: all deps init apply diff edit re-add merge hooks mise help
 
-# デフォルト: 依存ツールを揃えて apply、pre-commit hook を install
-all: deps apply hooks
+# デフォルト: 依存ツールを揃えて apply、mise install、pre-commit hook を install
+all: deps apply mise hooks
 
 deps:
 	@command -v brew >/dev/null 2>&1 || { echo "Homebrew が必要です: https://brew.sh"; exit 1; }
@@ -63,9 +63,14 @@ merge:
 	@test -n "$(FILE)" || { echo "Usage: make merge FILE=~/.zshrc"; exit 1; }
 	chezmoi merge --source "$(PWD)" "$(FILE)"
 
+# mise でランタイムを ~/.config/mise/config.toml の宣言通りに揃える (apply 後に実行する想定)
+mise:
+	@command -v mise >/dev/null 2>&1 || { echo "mise が見つからない: make deps を先に実行"; exit 1; }
+	mise install
+
 help:
 	@echo "Targets:"
-	@echo "  all      - deps + apply + hooks (デフォルト)"
+	@echo "  all      - deps + apply + mise + hooks (デフォルト)"
 	@echo "  deps     - brew bundle + npm install"
 	@echo "  init     - 初回のみ chezmoi 設定ファイルを生成"
 	@echo "  apply    - source → ~/ に反映 (標準の方向)"
@@ -73,4 +78,5 @@ help:
 	@echo "  edit     - source 側を編集して --apply (FILE=...)"
 	@echo "  re-add   - ~/ の編集内容を source に取り込み (FILE=... 任意)"
 	@echo "  merge    - 衝突時の 3-way merge (FILE=...)"
+	@echo "  mise     - ~/.config/mise/config.toml に従って mise install"
 	@echo "  hooks    - pre-commit hook を install (secretlint)"

--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -1,0 +1,5 @@
+[tools]
+node = "lts"
+pnpm = "latest"
+python = "latest"
+uv = "latest"


### PR DESCRIPTION
## What

- `Brewfile` に `brew "mise"` を追加
- `Makefile` に `mise` ターゲット (`mise install`) を追加し、デフォルト `all` を `deps + apply + mise + hooks` に拡張
- 既存の `~/.config/mise/config.toml` を `dot_config/mise/config.toml` として chezmoi 管理に取り込む (`node=lts`, `pnpm/python/uv=latest`)

## Why

新規 Mac で `make` 1 発で言語ランタイムまで揃う状態にする。

順序保証:
1. `deps` で brew が mise をインストール
2. `apply` で `~/.config/mise/config.toml` を配置
3. `mise` ターゲットが上記 config を読んで install

UMBRELLA.md S5 (devbox/direnv) との住み分け:
- mise:   ホーム / プロジェクト共通の言語ランタイム
- devbox: プロジェクト固有の Nix-based reproducible env (将来必要時)

## 補足

`packer`, `terraform` 等は現状 mise グローバル管理外なので一旦含めない。必要なら追記する。

## ベース

PR #88 ベース。

Refs: UMBRELLA.md S3 / PR5