### PR TITLE
feat: macOS defaults を ~/.macos + make macos で自動化 (S4)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PWD := $(shell pwd)
 
-.PHONY: all deps init apply diff edit re-add merge hooks mise help
+.PHONY: all deps init apply diff edit re-add merge hooks mise macos help
 
 # デフォルト: 依存ツールを揃えて apply、mise install、pre-commit hook を install
 all: deps apply mise hooks
@@ -68,6 +68,13 @@ mise:
 	@command -v mise >/dev/null 2>&1 || { echo "mise が見つからない: make deps を先に実行"; exit 1; }
 	mise install
 
+# macOS defaults を ~/.macos に従って一括適用する (デフォルト all には含めない: 副作用大)
+# 適用前に内容を確認するなら `cat ~/.macos`
+macos:
+	@[ "$$(uname)" = "Darwin" ] || { echo "macOS 専用です"; exit 1; }
+	@[ -x "$(HOME)/.macos" ] || { echo "~/.macos が無い: make apply を先に実行"; exit 1; }
+	"$(HOME)/.macos"
+
 help:
 	@echo "Targets:"
 	@echo "  all      - deps + apply + mise + hooks (デフォルト)"
@@ -79,4 +86,5 @@ help:
 	@echo "  re-add   - ~/ の編集内容を source に取り込み (FILE=... 任意)"
 	@echo "  merge    - 衝突時の 3-way merge (FILE=...)"
 	@echo "  mise     - ~/.config/mise/config.toml に従って mise install"
+	@echo "  macos    - ~/.macos の defaults を一括適用 (副作用大のため all には含めない)"
 	@echo "  hooks    - pre-commit hook を install (secretlint)"

--- a/executable_dot_macos
+++ b/executable_dot_macos
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# ~/.macos: macOS defaults を最小セットで揃える
+#
+# 適用は `make macos` から (デフォルト all には含めない: 副作用が大きいため)
+# 個別変更を増やしたい場合は Why コメント付きで追記する
+
+set -eu
+
+echo "[macos] applying defaults..."
+
+# ============================================================
+# Dock
+# ============================================================
+# Dock を自動的に隠す (画面領域を確保)
+defaults write com.apple.dock autohide -bool true
+
+# ============================================================
+# Finder
+# ============================================================
+# 全ての拡張子を表示 (.txt 等を隠さない)
+defaults write NSGlobalDomain AppleShowAllExtensions -bool true
+
+# 拡張子変更時の警告ダイアログを抑止
+defaults write com.apple.finder FXEnableExtensionChangeWarning -bool false
+
+# ============================================================
+# Screenshot
+# ============================================================
+# スクリーンショット保存先を ~/Pictures/Screenshots に集約
+mkdir -p "${HOME}/Pictures/Screenshots"
+defaults write com.apple.screencapture location -string "${HOME}/Pictures/Screenshots"
+
+# ============================================================
+# キーボード
+# ============================================================
+# キーリピート速度を最速に (2 = ~30ms)
+defaults write NSGlobalDomain KeyRepeat -int 2
+# キーリピート開始までの遅延 (15 = ~225ms)
+defaults write NSGlobalDomain InitialKeyRepeat -int 15
+
+# ============================================================
+# Safari (開発者向け)
+# ============================================================
+# 開発メニューと内部デバッグメニューを表示
+defaults write com.apple.Safari IncludeDevelopMenu -bool true
+defaults write com.apple.Safari IncludeInternalDebugMenu -bool true
+defaults write NSGlobalDomain WebKitDeveloperExtras -bool true
+
+# ============================================================
+# 反映 (該当プロセスを再起動)
+# ============================================================
+for app in "Dock" "Finder" "SystemUIServer"; do
+  killall "${app}" >/dev/null 2>&1 || true
+done
+
+echo "[macos] done. Safari は手動再起動が必要な場合あり。"


### PR DESCRIPTION
## What

- `executable_dot_macos` を追加 (chezmoi が `~/.macos` に 0755 で配置)
- 最小セット:
  - Dock 自動非表示
  - Finder 拡張子表示 + 拡張子変更警告抑止
  - スクショ保存先を `~/Pictures/Screenshots`
  - キーリピート最速 (KeyRepeat=2, InitialKeyRepeat=15)
  - Safari 開発メニュー有効化
- `Makefile` に `macos` ターゲット追加 (`~/.macos` を実行)。**デフォルト `all` には含めない** (副作用大)
- macOS 専用判定 (`uname == Darwin`) と `~/.macos` 存在チェックを target 内で実施

## Why

- 新規 Mac で OS レベルの調整も復元できるようにする
- 実行を opt-in (`make macos`) にすることで、リモート Mac や VM では適用しない選択肢を残す

## 後続

増やす時は **Why コメント** をスクリプト本体に併記する (なぜその defaults を変えたいか)。

## ベース

PR #89 ベース。

Refs: UMBRELLA.md S4 / PR6