### PR TITLE
chore: retrospective フォローアップ（pre-commit cache / hook コメント / model 固定）

### DIFF
--- a/dot_claude/hooks/suggest-retrospective.sh
+++ b/dot_claude/hooks/suggest-retrospective.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 # セッション終了時に retrospective-codify 実行を促す Stop hook
 # session_id ベースのセンチネルで1セッションにつき1回だけ発火
+#
+# NOTE: Stop hook の出力 JSON で hookSpecificOutput.additionalContext は
+# 使えない（UserPromptSubmit / PostToolUse / PostToolBatch 専用）。
+# Claude への指示は decision: block + reason に直接書く。
 SESSION_ID=$(jq -r '.session_id // empty')
 if [ -z "$SESSION_ID" ]; then
   echo '{}'

--- a/dot_claude/settings.json
+++ b/dot_claude/settings.json
@@ -28,7 +28,10 @@
         "~/.bash_history",
         "~/.zsh_history"
       ],
-      "allowRead": []
+      "allowRead": [],
+      "allowWrite": [
+        "~/.cache/pre-commit"
+      ]
     }
   },
   "permissions": {

--- a/dot_claude/skills/retrospective-codify/SKILL.md
+++ b/dot_claude/skills/retrospective-codify/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: retrospective-codify
 description: セッション終了時または「学びを残して」と指示されたときに、今回のタスクから「最初に知っていれば遠回りしなかった」知見を抽出し、ast-grep ルール / skill / CLAUDE.md(rules) ルールのいずれかに固定する。プロンプトに頼らず再現可能な形に落とすことを優先する。
+model: sonnet
 ---
 
 # Retrospective Codify


### PR DESCRIPTION
## What

PR #92 のレビュー後フォローアップ 3 点。

1. **pre-commit cache の sandbox 許可** (`dot_claude/settings.json`)
   - \`sandbox.filesystem.allowWrite\` に \`~/.cache/pre-commit\` を追加
   - これまで git commit のたびに \`dangerouslyDisableSandbox: true\` が必要だった
2. **hook スクリプトに NOTE コメント** (\`dot_claude/hooks/suggest-retrospective.sh\`)
   - \`hookSpecificOutput.additionalContext\` が Stop event で使えない仕様をインラインで残す
   - CLAUDE.md にルール化すると常時コンテキストに載るので回避（hook 編集者が必ず目にする場所に配置）
3. **retrospective-codify のモデル固定** (\`dot_claude/skills/retrospective-codify/SKILL.md\`)
   - frontmatter に \`model: sonnet\` を追加
   - 分類中心の作業で Opus は過剰

## Why

セッション内で実際に詰まった摩擦を解消する。retrospective-codify の合議結果として
\`[rule]\` 候補は CLAUDE.md には載せず hook コメント + settings.json で対応する方針。

## 動作確認

- (1) 次の git commit が sandbox 内で通るか
- (2) hook の挙動は変わらず（コメントのみの変更）
- (3) 次のセッションの retrospective が sonnet で動くか（loader が frontmatter を honor するか）

(3) が効いていなければ subagent dispatch に切り替えて再対応。