### PR TITLE
chore: run_once_before_install-deps.sh.tmpl を削除 (PR #91 再投)

### DIFF
--- a/run_once_before_install-deps.sh.tmpl
+++ b/run_once_before_install-deps.sh.tmpl
@@ -1,8 +1,0 @@
-#!/bin/sh
-set -eu
-
-{{- if eq .chezmoi.os "darwin" }}
-if command -v brew >/dev/null 2>&1; then
-  brew install --cask font-plemol-jp-nf 2>/dev/null || true
-fi
-{{- end }}


### PR DESCRIPTION
## What

`run_once_before_install-deps.sh.tmpl` をファイルごと削除。

## Why

Vim 撤去 (PR #85) で vim-plug DL ブロックを取り除いた結果、残る処理は `brew install --cask font-plemol-jp-nf` のみ。Brewfile に既に `cask "font-plemol-jp-nf"` が存在するため完全な重複。chezmoi の `run_once` フックごと撤去する。

## 経緯

PR #91 は GitHub 上 `merged` 表示だが、merge commit (`4b07b16`) が PR #90 の force-push で orphan 化して master に landing しなかったため再投。

Refs: UMBRELLA.md A4 / PR8