### PR TITLE
fix: retrospective Stop hook を plan mode 終了時に発火させない

### DIFF
--- a/dot_claude/hooks/suggest-retrospective.sh
+++ b/dot_claude/hooks/suggest-retrospective.sh
@@ -5,7 +5,9 @@
 # NOTE: Stop hook の出力 JSON で hookSpecificOutput.additionalContext は
 # 使えない（UserPromptSubmit / PostToolUse / PostToolBatch 専用）。
 # Claude への指示は decision: block + reason に直接書く。
-SESSION_ID=$(jq -r '.session_id // empty')
+INPUT=$(cat)
+SESSION_ID=$(jq -r '.session_id // empty' <<<"$INPUT")
+TRANSCRIPT=$(jq -r '.transcript_path // empty' <<<"$INPUT")
 if [ -z "$SESSION_ID" ]; then
   echo '{}'
   exit 0
@@ -15,6 +17,20 @@ SENTINEL="${TMPDIR:-/tmp}/claude-retrospective-${SESSION_ID}"
 if [ -f "$SENTINEL" ]; then
   echo '{}'
   exit 0
+fi
+
+# Stop hook は plan mode 終了 / /compact / /clear でも発火する。
+# 直近の tool_use が ExitPlanMode なら、計画承認直後の Stop と判断して suppress。
+# センチネルは作らない: 後続の通常ターン終了で改めて発火させたい。
+# /compact /clear の痕跡は未調査 (TODO).
+if [ -n "$TRANSCRIPT" ] && [ -f "$TRANSCRIPT" ]; then
+  last_tool=$(tac "$TRANSCRIPT" 2>/dev/null \
+    | jq -r 'select(.type=="assistant") | .message.content[]? | select(.type=="tool_use") | .name' 2>/dev/null \
+    | head -1)
+  if [ "$last_tool" = "ExitPlanMode" ]; then
+    echo '{}'
+    exit 0
+  fi
 fi
 
 touch "$SENTINEL"


### PR DESCRIPTION
## What
Stop hook (`dot_claude/hooks/suggest-retrospective.sh`) で、直近の tool_use が `ExitPlanMode` の場合は suppress するガードを追加。

## Why
Stop hook は通常のターン終了に加えて plan mode 終了 / `/compact` / `/clear` でも発火する仕様。
そのため計画を立てて承認しただけのタイミングで「学びを残してください」とブロックされ、本作業に入る前に一手詰まる問題があった。

SessionEnd は session 終了**後**に走るため `decision: block` で Claude にタスク依頼する用途には使えず、Stop hook 内で plan mode 終了を検出して抑止するのが妥当。

センチネルはこのケースでは作らないため、後続の通常ターン終了で改めて retrospective が発火する。

## 検証
- 単体テスト (fixture transcript で dry-run): plan mode ケースは `{}`、通常ケースは block JSON、2回目はセンチネルで `{}`
- `/compact` `/clear` 時の挙動は未調査 (TODO)