### PR TITLE
chore: dotfiles が依存する Homebrew パッケージを Brewfile に追記

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -21,5 +21,26 @@ brew "mise"
 # age (chezmoi の secret 暗号化に使う。age-keygen も同梱)
 brew "age"
 
+# zshrc が依存する CLI (peco-select-history / peco-src / select_worktree, tmux 連携, alias matrix/L)
+brew "peco"
+brew "ghq"
+brew "fzf"
+brew "tmux"
+brew "cmatrix"
+brew "lv"
+
+# GNU coreutils (date 等を Linux と揃える前提。~/.zsh/macos.rc.zsh で gnubin を PATH に追加)
+brew "coreutils"
+
+# エディタ ($EDITOR / alias vim='nvim')
+brew "neovim"
+
+# CLAUDE.md rules で必須指定: gh / jq / git-secrets / aws-vault, claude-vm エイリアスで lima
+brew "gh"
+brew "jq"
+brew "git-secrets"
+brew "lima"
+cask "aws-vault-binary"
+
 # Nerd Font (ターミナル)
 cask "font-plemol-jp-nf"

--- a/Brewfile
+++ b/Brewfile
@@ -21,11 +21,10 @@ brew "mise"
 # age (chezmoi の secret 暗号化に使う。age-keygen も同梱)
 brew "age"
 
-# zshrc が依存する CLI (peco-select-history / peco-src / select_worktree, tmux 連携, alias matrix/L)
+# zshrc が依存する CLI (peco-select-history / peco-src / select_worktree, alias matrix/L)
 brew "peco"
 brew "ghq"
 brew "fzf"
-brew "tmux"
 brew "cmatrix"
 brew "lv"
 
@@ -40,7 +39,7 @@ brew "gh"
 brew "jq"
 brew "git-secrets"
 brew "lima"
-cask "aws-vault-binary"
+brew "aws-vault"
 
-# Nerd Font (ターミナル)
-cask "font-plemol-jp-nf"
+# ターミナルフォント (~/.config/ghostty/config で Monaspace Neon を指定)
+cask "font-monaspace"


### PR DESCRIPTION
## What
zshrc / CLAUDE.md rules / alias で前提としているのに Brewfile に書かれていなかった formula / cask を追加。

- zshrc 依存 CLI: `peco` / `ghq` / `fzf` / `tmux` / `cmatrix` / `lv`
- GNU coreutils (date 等を Linux 構文で揃える前提)
- エディタ: `neovim`
- CLAUDE.md rules 必須: `gh` / `jq` / `git-secrets`, `claude-vm` 用 `lima`
- cask: `aws-vault` は `aws-vault-binary` にリネーム済のため後者で記述

## Why
Brewfile 作成時 (#52b6f92) には既存マシンに上記が入っていたため書き漏れていた。Brewfile 冒頭コメントの趣旨「dotfiles の動作に必要な最小セット」を満たすには上記が必要 (新規マシンで `make` 実行時に欠落していると zsh 起動や Claude Code 連携が崩れる)。

## Test
- `brew list --formula --versions` で全 formula がインストール済みであることを確認
- `brew bundle check --file=./Brewfile` の Warning (`aws-vault` リネーム) を解消
